### PR TITLE
Update inlist options for MESA experiments

### DIFF
--- a/Lane-Emden/0.3M-entropy/inlist
+++ b/Lane-Emden/0.3M-entropy/inlist
@@ -6,42 +6,42 @@
 
 &star_job
 
-    read_extra_star_job_inlist1 = .true.
-    extra_star_job_inlist1_name = 'inlist_0.3M'
+    read_extra_star_job_inlist(1) = .true.
+    extra_star_job_inlist_name(1) = 'inlist_0.3M'
 
 / ! end of star_job namelist
 
 
 &eos
 
-    read_extra_eos_inlist1 = .true.
-    extra_eos_inlist1_name = 'inlist_0.3M'
+    read_extra_eos_inlist(1) = .true.
+    extra_eos_inlist_name(1) = 'inlist_0.3M'
 
 / ! end of eos namelist
 
 
 &kap
 
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_0.3M'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_0.3M'
 
 / ! end of kap namelist
 
 
 &controls
 
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_0.3M'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1) = 'inlist_0.3M'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-    read_extra_pgstar_inlist1 = .true.
-    extra_pgstar_inlist1_name = 'inlist_pgstar'
+    read_extra_pgstar_inlist(1) = .true.
+    extra_pgstar_inlist_name(1) = 'inlist_pgstar'
     
-    read_extra_pgstar_inlist2 = .false.
-    extra_pgstar_inlist2_name = 'inlist_entropy'
+    read_extra_pgstar_inlist(2) = .false.
+    extra_pgstar_inlist_name(2) = 'inlist_entropy'
 
 / ! end of pgstar namelist

--- a/convection/1M-convection/inlist
+++ b/convection/1M-convection/inlist
@@ -6,42 +6,42 @@
 
 &star_job
 
-    read_extra_star_job_inlist1 = .true.
-    extra_star_job_inlist1_name = 'inlist_1M_convection'
+    read_extra_star_job_inlist(1) = .true.
+    extra_star_job_inlist_name(1) = 'inlist_1M_convection'
 
 / ! end of star_job namelist
 
 
 &eos
 
-    read_extra_eos_inlist1 = .true.
-    extra_eos_inlist1_name = 'inlist_1M_convection'
+    read_extra_eos_inlist(1) = .true.
+    extra_eos_inlist_name(1) = 'inlist_1M_convection'
 
 / ! end of eos namelist
 
 
 &kap
 
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_1M_convection'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_1M_convection'
 
 / ! end of kap namelist
 
 
 &controls
 
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_1M_convection'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1) = 'inlist_1M_convection'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-    read_extra_pgstar_inlist1 = .true.
-    extra_pgstar_inlist1_name = 'inlist_pgstar'
+    read_extra_pgstar_inlist(1) = .true.
+    extra_pgstar_inlist_name(1) = 'inlist_pgstar'
 
-    read_extra_pgstar_inlist2 = .true.
-    extra_pgstar_inlist2_name = 'inlist_convection_vars'
+    read_extra_pgstar_inlist(2) = .true.
+    extra_pgstar_inlist_name(2) = 'inlist_convection_vars'
 
 / ! end of pgstar namelist

--- a/convection/1M-convection/inlist_1M_convection
+++ b/convection/1M-convection/inlist_1M_convection
@@ -10,7 +10,7 @@
 
   ! begin with saved model from previous exercise
     load_saved_model = .true.
-    saved_model_name = '1M_PMS.mod'
+    load_model_filename = '1M_PMS.mod'
 
     ! helpful to pause before ending
     pause_before_terminate = .true. 

--- a/introduction/1M-pms/inlist
+++ b/introduction/1M-pms/inlist
@@ -6,42 +6,42 @@
 
 &star_job
 
-    read_extra_star_job_inlist1 = .true.
-    extra_star_job_inlist1_name = 'inlist_1M_pms'
+    read_extra_star_job_inlist(1) = .true.
+    extra_star_job_inlist_name(1) = 'inlist_1M_pms'
 
 / ! end of star_job namelist
 
 
 &eos
 
-    read_extra_eos_inlist1 = .true.
-    extra_eos_inlist1_name = 'inlist_1M_pms'
+    read_extra_eos_inlist(1) = .true.
+    extra_eos_inlist_name(1) = 'inlist_1M_pms'
 
 / ! end of eos namelist
 
 
 &kap
 
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_1M_pms'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_1M_pms'
 
 / ! end of kap namelist
 
 
 &controls
 
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_1M_pms'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1) = 'inlist_1M_pms'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-    read_extra_pgstar_inlist1 = .true.
-    extra_pgstar_inlist1_name = 'inlist_pgstar'
+    read_extra_pgstar_inlist(1) = .true.
+    extra_pgstar_inlist_name(1) = 'inlist_pgstar'
     
-    read_extra_pgstar_inlist2 = .true.
-    extra_pgstar_inlist2_name = 'inlist_track_central_vars'
+    read_extra_pgstar_inlist(2) = .true.
+    extra_pgstar_inlist_name(2) = 'inlist_track_central_vars'
 
 / ! end of pgstar namelist

--- a/radiation/beta-eddington/inlist_10M
+++ b/radiation/beta-eddington/inlist_10M
@@ -6,24 +6,24 @@
 
 &star_job
 
-    read_extra_star_job_inlist1 = .true.
-    extra_star_job_inlist1_name = 'inlist_common'
+    read_extra_star_job_inlist(1) = .true.
+    extra_star_job_inlist_name(1) = 'inlist_common'
 
 / ! end of star_job namelist
 
 
 &eos
 
-    read_extra_eos_inlist1 = .true.
-    extra_eos_inlist1_name = 'inlist_common'
+    read_extra_eos_inlist(1) = .true.
+    extra_eos_inlist_name(1) = 'inlist_common'
 
 / ! end of eos namelist
 
 
 &kap
 
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_common'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_common'
 
 / ! end of kap namelist
 
@@ -37,18 +37,18 @@
     photo_directory = '10M/photos'
     log_directory = '10M/LOGS'
     
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_common'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1) = 'inlist_common'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-    read_extra_pgstar_inlist1 = .true.
-    extra_pgstar_inlist1_name = 'inlist_pgstar'
+    read_extra_pgstar_inlist(1) = .true.
+    extra_pgstar_inlist_name(1) = 'inlist_pgstar'
 
-    read_extra_pgstar_inlist2 = .false.
-    extra_pgstar_inlist2_name = 'inlist_radn_vars'
+    read_extra_pgstar_inlist(2) = .false.
+    extra_pgstar_inlist_name(2) = 'inlist_radn_vars'
 
 / ! end of pgstar namelist

--- a/radiation/beta-eddington/inlist_1M
+++ b/radiation/beta-eddington/inlist_1M
@@ -6,24 +6,24 @@
 
 &star_job
 
-    read_extra_star_job_inlist1 = .true.
-    extra_star_job_inlist1_name = 'inlist_common'
+    read_extra_star_job_inlist(1) = .true.
+    extra_star_job_inlist_name(1) = 'inlist_common'
 
 / ! end of star_job namelist
 
 
 &eos
 
-    read_extra_eos_inlist1 = .true.
-    extra_eos_inlist1_name = 'inlist_common'
+    read_extra_eos_inlist(1) = .true.
+    extra_eos_inlist_name(1) = 'inlist_common'
 
 / ! end of eos namelist
 
 
 &kap
 
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_common'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_common'
 
 / ! end of kap namelist
 
@@ -36,18 +36,18 @@
     photo_directory = '1M/photos'
     log_directory = '1M/LOGS'
 
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_common'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1) = 'inlist_common'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-    read_extra_pgstar_inlist1 = .true.
-    extra_pgstar_inlist1_name = 'inlist_pgstar'
+    read_extra_pgstar_inlist(1) = .true.
+    extra_pgstar_inlist_name(1) = 'inlist_pgstar'
 
-    read_extra_pgstar_inlist2 = .false.
-    extra_pgstar_inlist2_name = 'inlist_radn_vars'
+    read_extra_pgstar_inlist(2) = .false.
+    extra_pgstar_inlist_name(2) = 'inlist_radn_vars'
 
 / ! end of pgstar namelist

--- a/radiation/beta-eddington/inlist_30M
+++ b/radiation/beta-eddington/inlist_30M
@@ -6,24 +6,24 @@
 
 &star_job
 
-    read_extra_star_job_inlist1 = .true.
-    extra_star_job_inlist1_name = 'inlist_common'
+    read_extra_star_job_inlist(1) = .true.
+    extra_star_job_inlist_name(1) = 'inlist_common'
 
 / ! end of star_job namelist
 
 
 &eos
 
-    read_extra_eos_inlist1 = .true.
-    extra_eos_inlist1_name = 'inlist_common'
+    read_extra_eos_inlist(1) = .true.
+    extra_eos_inlist_name(1) = 'inlist_common'
 
 / ! end of eos namelist
 
 
 &kap
 
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_common'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_common'
 
 / ! end of kap namelist
 
@@ -36,18 +36,18 @@
     photo_directory = '30M/photos'
     log_directory = '30M/LOGS'
     
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_common'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1) = 'inlist_common'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-    read_extra_pgstar_inlist1 = .true.
-    extra_pgstar_inlist1_name = 'inlist_pgstar'
+    read_extra_pgstar_inlist(1) = .true.
+    extra_pgstar_inlist_name(1) = 'inlist_pgstar'
 
-    read_extra_pgstar_inlist2 = .false.
-    extra_pgstar_inlist2_name = 'inlist_radn_vars'
+    read_extra_pgstar_inlist(2) = .false.
+    extra_pgstar_inlist_name(2) = 'inlist_radn_vars'
 
 / ! end of pgstar namelist

--- a/radiation/beta-eddington/inlist_3M
+++ b/radiation/beta-eddington/inlist_3M
@@ -6,24 +6,24 @@
 
 &star_job
 
-    read_extra_star_job_inlist1 = .true.
-    extra_star_job_inlist1_name = 'inlist_common'
+    read_extra_star_job_inlist(1) = .true.
+    extra_star_job_inlist_name(1) = 'inlist_common'
 
 / ! end of star_job namelist
 
 
 &eos
 
-    read_extra_eos_inlist1 = .true.
-    extra_eos_inlist1_name = 'inlist_common'
+    read_extra_eos_inlist(1) = .true.
+    extra_eos_inlist_name(1) = 'inlist_common'
 
 / ! end of eos namelist
 
 
 &kap
 
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_common'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_common'
 
 / ! end of kap namelist
 
@@ -36,8 +36,8 @@
     photo_directory = '3M/photos'
     log_directory = '3M/LOGS'
     
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_common'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1) = 'inlist_common'
     
 
 / ! end of controls namelist
@@ -45,10 +45,10 @@
 
 &pgstar
 
-    read_extra_pgstar_inlist1 = .true.
-    extra_pgstar_inlist1_name = 'inlist_pgstar'
+    read_extra_pgstar_inlist(1) = .true.
+    extra_pgstar_inlist_name(1) = 'inlist_pgstar'
 
-    read_extra_pgstar_inlist2 = .false.
-    extra_pgstar_inlist2_name = 'inlist_radn_vars'
+    read_extra_pgstar_inlist(2) = .false.
+    extra_pgstar_inlist_name(2) = 'inlist_radn_vars'
 
 / ! end of pgstar namelist


### PR DESCRIPTION
Newer MESA versions use array style reading options for redirecting inlists. Also, the option for using a different model has been changed to load_model_filename (https://docs.mesastar.org/en/stable/reference/star_job.html#load-model-filename)